### PR TITLE
Update: AbstractRepository resource building

### DIFF
--- a/app/Support/Repositories/AbstractRepository.php
+++ b/app/Support/Repositories/AbstractRepository.php
@@ -7,8 +7,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\Request;
 use Illuminate\Support\Traits\ForwardsCalls;
 use InvalidArgumentException;
-use Support\Http\Resources\AbstractResource;
-use Support\Http\Resources\ResourceCollection;
+use Support\Repositories\Concerns\BuildsResources;
 use Support\Repositories\Contracts\RepositoryContract;
 
 /**
@@ -17,6 +16,7 @@ use Support\Repositories\Contracts\RepositoryContract;
 abstract class AbstractRepository implements RepositoryContract
 {
     use ForwardsCalls;
+    use BuildsResources;
 
     protected Builder $query;
 
@@ -72,24 +72,6 @@ abstract class AbstractRepository implements RepositoryContract
         $this->paginationPerPage = $perPage;
 
         return $this;
-    }
-
-    public function toResources(): ResourceCollection
-    {
-        $class = $this->getResourceClass();
-
-        return $class::collection(
-            $this->fetch()
-        );
-    }
-
-    public function toResource(): AbstractResource
-    {
-        $class = $this->getResourceClass();
-
-        return new $class(
-            $this->fetch()->first()
-        );
     }
 
     /*

--- a/app/Support/Repositories/Concerns/BuildsResources.php
+++ b/app/Support/Repositories/Concerns/BuildsResources.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Support\Repositories\Concerns;
+
+use BadMethodCallException;
+use Illuminate\Http\Request;
+use stdClass;
+use Support\Http\Resources\AbstractResource;
+use Support\Http\Resources\ResourceCollection;
+
+trait BuildsResources
+{
+    public function toResources(): ResourceCollection
+    {
+        $class = $this->getResourceClass();
+
+        if ( ! method_exists($class, 'collection')) {
+            throw new BadMethodCallException("Can not build given repository resource class to collection");
+        }
+
+        return $class::collection(
+            $this->fetch()
+        );
+    }
+
+    public function toResource(): ?AbstractResource
+    {
+        $class = $this->getResourceClass();
+
+        $result = $this->fetch()->first();
+
+        if ($result === null) {
+            return null;
+        }
+
+        return new $class($result);
+    }
+
+    public function toView(Request $request, bool $collection): ?stdClass
+    {
+        $resources = null;
+
+        if ($collection) {
+            return $this->toResources()->toView($request);
+        }
+
+        $resource = $this->toResource();
+
+        if ($resource === null) {
+            return null;
+        }
+
+        return $resource->toView($request);
+    }
+
+    public function oneToView(Request $request): ?stdClass
+    {
+        return $this->toView($request, false);
+    }
+
+    public function manyToView(Request $request): stdClass
+    {
+        return $this->toView($request, true);
+    }
+
+    abstract protected function fetch();
+
+    abstract public function getModelClass(): string;
+
+    abstract public function getResourceClass(): string;
+}


### PR DESCRIPTION
- Add `oneToView(Request $request): ?stdClass` as alias of `toView(Request $request, false): ?stdClass`
- Add `manyToView(Request $request): stdClass` as alias of `toView(Request $request, true): ?stdClass`
- Move resource building in `AbstractRepository` to own trait
- Fix null exception when trying to build query to single resource but query has no results